### PR TITLE
Harvest Report Update Endpoint

### DIFF
--- a/src/Resources/Base/Resource.php
+++ b/src/Resources/Base/Resource.php
@@ -123,7 +123,7 @@ abstract class Resource
     {
         $reflection = new ReflectionClass($this);
 
-        return $reflection->getShortName();
+        return $this->snakeCase($reflection->getShortName());
     }
 
     /**

--- a/src/Resources/Base/Resource.php
+++ b/src/Resources/Base/Resource.php
@@ -123,7 +123,7 @@ abstract class Resource
     {
         $reflection = new ReflectionClass($this);
 
-        return $this->snakeCase($reflection->getShortName());
+        return $reflection->getShortName();
     }
 
     /**

--- a/src/Resources/ViewReportsHarvestReports.php
+++ b/src/Resources/ViewReportsHarvestReports.php
@@ -25,7 +25,7 @@ class ViewReportsHarvestReports extends Resource
      * @param array  $harvestReportIds            Array of Harvest Report IDs
      * @return \SmartOysters\FarmOpsX\Http\Response
      */
-    public function updateReport(string $harvestGradingEntryId, ?array $harvestReportIds = [])
+    public function updateReport(string $harvestGradingEntryId, array $harvestReportIds)
     {
         $options = array_merge(compact('harvestGradingEntryId'), [
             'harvest_report_ids' => $harvestReportIds

--- a/src/Resources/ViewReportsHarvestReports.php
+++ b/src/Resources/ViewReportsHarvestReports.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the FarmOpsX API PHP Package
+ *
+ * (c) James Rickard <james.rickard@smartoysters.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SmartOysters\FarmOpsX\Resources;
+
+use SmartOysters\FarmOpsX\Resources\Base\Resource;
+use SmartOysters\FarmOpsX\Response;
+
+class ViewReportsHarvestReports extends Resource
+{
+    protected $disabled = ['list', 'fetch', 'create', 'update'];
+
+    /**
+     * Update a Harvest Report
+     *
+     * @param string $harvestGradingEntryId       Harvest Grading Entry ID to be updated
+     * @param array  $harvestReportIds            Array of Harvest Report IDs
+     * @return \SmartOysters\FarmOpsX\Http\Response
+     */
+    public function updateReport(string $harvestGradingEntryId, ?array $harvestReportIds = [])
+    {
+        $options = array_merge(compact('harvestGradingEntryId'), [
+            'harvest_report_ids' => $harvestReportIds
+        ]);
+
+        return $this->request->post(':harvestGradingEntryId/update', $options);
+    }
+}

--- a/src/Resources/ViewReportsHarvestReports.php
+++ b/src/Resources/ViewReportsHarvestReports.php
@@ -11,6 +11,7 @@
 
 namespace SmartOysters\FarmOpsX\Resources;
 
+use ReflectionClass;
 use SmartOysters\FarmOpsX\Resources\Base\Resource;
 use SmartOysters\FarmOpsX\Response;
 
@@ -32,5 +33,17 @@ class ViewReportsHarvestReports extends Resource
         ]);
 
         return $this->request->post(':harvestGradingEntryId/update', $options);
+    }
+
+    /**
+     * Get the endpoint name based on the name class.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        $reflection = new ReflectionClass($this);
+
+        return $reflection->getShortName();
     }
 }


### PR DESCRIPTION
## Pull Request

### Summary of Changes

Add a `ViewReportsHarvestReports` resource class with the API query to update a report.

Remove the snake casing of the class name as there's no `view_reports_harvest_report` endpoint.

### Bugs/Issues Fixed

* [ ] Monday: #7056118400